### PR TITLE
Fix bug when allowDecimals is false

### DIFF
--- a/jquery.jstepper.js
+++ b/jquery.jstepper.js
@@ -145,6 +145,10 @@ function AddOrSubtractTwoFloats(fltValue1, fltValue2, bAddSubtract) {
 			strValue = strValue.replace(/[^\d\.,\-]/gi, '');
 		}
 
+		if (!o.allowDecimals) {
+        	    	strValue = strValue.replace(/[^\d\-]/gi, '');
+        	}
+
 		if (o.maxValue !== null) {
 			if (strValue >= o.maxValue) {
 				strValue = o.maxValue;


### PR DESCRIPTION
Disallow direct input of "." and "," if allowDecimals is false.
Only "-" and numbers are allowed.
